### PR TITLE
Update SVGParser.java

### DIFF
--- a/src/main/java/com/bonnyfone/vectalign/SVGParser.java
+++ b/src/main/java/com/bonnyfone/vectalign/SVGParser.java
@@ -62,10 +62,15 @@ public class SVGParser {
 
     private static Document getXMLDocumentFromFile(File f) throws ParserConfigurationException, IOException, SAXException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setNamespaceAware(false);
+        factory.setNamespaceAware(true);
         factory.setValidating(false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
         factory.setFeature("http://xml.org/sax/features/namespaces", false);
         factory.setFeature("http://xml.org/sax/features/validation", false);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         factory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false);
         factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
         DocumentBuilder builder = null;


### PR DESCRIPTION
### 📊 Metadata *

VectAlign (a.k.a. VectorDrawableAlign) is a developer's tool which automagically aligns two VectorDrawable "pathData" strings (or SVG images) in order to allow morphing animations between them using an AnimatedVectorDrawable. 

#### Bounty URL: https://www.huntr.dev/bounties/1-other-vectalign

### ⚙️ Description *

VectAlign (a.k.a. VectorDrawableAlign) is vulnerable to (XXE) Vulnerability.

### 💻 Technical Description *

OWASP recommends ACCESS_EXTERNAL_DTD and ACCESS_EXTERNAL_STYLESHEET but it's mainly centered for the TransformerFactory Parser. As it's implemented in DocumentBuilderFactory and has been used in other functions as well, I wrote a fix for it rather than switching to any other parsers.

### 🐛 Proof of Concept (PoC) *
1. download and run https://bintray.com/artifact/download/bonnyfone/maven/vectalign-0.2-jar-with-dependencies.jar
2. create a payload svg or use : (this is a example of External XML Inclusion)
*https://drive.google.com/drive/folders/1CLc0cYmz6Q-CGnMpDnupx7YTjNzo8Eir?usp=sharing
POC IMAGE
*https://drive.google.com/file/d/1VqfAgldmtY-qrgHRfizVvAH2oIFZVT-q/view

### 🔥 Proof of Fix (PoF) *

XXE is Fixed

### 👍 User Acceptance Testing (UAT)

After fix functionality is unaffected.

### 🔗 Relates to...

https://www.huntr.dev/bounties/1-other-vectalign
